### PR TITLE
fix: scroll to top

### DIFF
--- a/src/lib/header/Header.svelte
+++ b/src/lib/header/Header.svelte
@@ -38,6 +38,7 @@
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		text-decoration: none;
+		scroll-margin-top: 20px;
 	}
 
 	nav > :first-child {


### PR DESCRIPTION
Add `scroll-margin-top` to scroll beyond the logo text, making it look like we've scrolled to the top of the page.

| Before when clicking 👆🏻 | After when clicking 👆🏻 |
| ------ | ----- |
| <img width="234" alt="Screenshot 2022-06-10 at 20 17 59" src="https://user-images.githubusercontent.com/1478102/173126989-06fbdc99-2dbb-4bb2-a085-dede01c5c2fb.png"> | <img width="180" alt="Screenshot 2022-06-10 at 20 18 12" src="https://user-images.githubusercontent.com/1478102/173127021-6afeddf2-a7b5-47d1-93bd-767149aee085.png"> |